### PR TITLE
color: inherit causes links to look like plain text

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -406,7 +406,6 @@ form {
   }
 
   a {
-    color: inherit;
     &::before {
       content: '[';
     }


### PR DESCRIPTION
`inherit` causes the element to take the computed value of the property from its parent. As that's a `<p>` it makes it the same colour as the text.

**Before**
![before](https://cloud.githubusercontent.com/assets/25522/24611328/aab6aa92-1879-11e7-8b67-37ff148f1a76.png)

**After**
![after](https://cloud.githubusercontent.com/assets/25522/24611334/af84671c-1879-11e7-9079-16906bf3c0fb.png)
